### PR TITLE
Add smart home mode channel

### DIFF
--- a/bundles/org.openhab.binding.myuplink/src/main/java/org/openhab/binding/myuplink/internal/MyUplinkBindingConstants.java
+++ b/bundles/org.openhab.binding.myuplink/src/main/java/org/openhab/binding/myuplink/internal/MyUplinkBindingConstants.java
@@ -68,8 +68,10 @@ public class MyUplinkBindingConstants {
     public static final String CHANNEL_TYPE_ON_OFF = "type-on-off";
     public static final String CHANNEL_TYPE_RW_SWITCH = "rwtype-switch";
     public static final String CHANNEL_TYPE_RW_COMMAND = "rwtype-command";
+    public static final String CHANNEL_TYPE_RW_MODE = "rwtype-mode";
 
     public static final String CHANNEL_ID_COMMAND = "command";
+    public static final String CHANNEL_ID_SMART_HOME_MODE = "smart-home-mode";
 
     // JSON Keys
     public static final String JSON_KEY_ROOT_DATA = "data";
@@ -85,6 +87,7 @@ public class MyUplinkBindingConstants {
     public static final String JSON_KEY_CHANNEL_MAX = "maxValue";
     public static final String JSON_KEY_CHANNEL_STEP = "stepValue";
     public static final String JSON_KEY_SYSTEMS = "systems";
+    public static final String JSON_KEY_SYSTEM_ID = "systemId";
     public static final String JSON_KEY_DEVICES = "devices";
     public static final String JSON_KEY_GENERIC_ID = "id";
     public static final String JSON_KEY_PRODUCT = "product";
@@ -93,6 +96,7 @@ public class MyUplinkBindingConstants {
     public static final String JSON_KEY_CURRENT_FW_VERSION = "currentFwVersion";
     public static final String JSON_KEY_CONNECTION_STATE = "connectionState";
     public static final String JSON_KEY_ERROR = "error";
+    public static final String JSON_KEY_SMART_HOME_MODE = "smartHomeMode";
 
     public static final String JSON_KEY_AUTH_ACCESS_TOKEN = "access_token";
     public static final String JSON_KEY_AUTH_EXPIRES_IN = "expires_in";
@@ -143,6 +147,8 @@ public class MyUplinkBindingConstants {
     private static final String API_BASE_URL = "https://api.myuplink.com";
     public static final String LOGIN_URL = API_BASE_URL + "/oauth/token";
     public static final String GET_SYSTEMS_URL = API_BASE_URL + "/v2/systems/me";
+    public static final String GET_SMART_HOME_MODE_URL = API_BASE_URL + "/v2/systems/{systemId}/smart-home-mode";
+    public static final String SET_SMART_HOME_MODE_URL = GET_SMART_HOME_MODE_URL;
     public static final String GET_DEVICE_POINTS = API_BASE_URL + "/v2/devices/{deviceId}/points";
     public static final String SET_DEVICE_POINTS = GET_DEVICE_POINTS;
 
@@ -161,6 +167,7 @@ public class MyUplinkBindingConstants {
     public static final String EMPTY = "";
 
     public static final String THING_CONFIG_ID = "deviceId";
+    public static final String THING_CONFIG_SYSTEM_ID = "systemId";
     public static final String THING_CONFIG_SERIAL = "serial";
     public static final String THING_CONFIG_CURRENT_FW_VERSION = "currentFwVersion";
 

--- a/bundles/org.openhab.binding.myuplink/src/main/java/org/openhab/binding/myuplink/internal/command/AbstractCommand.java
+++ b/bundles/org.openhab.binding.myuplink/src/main/java/org/openhab/binding/myuplink/internal/command/AbstractCommand.java
@@ -35,6 +35,7 @@ import org.eclipse.jetty.http.HttpStatus.Code;
 import org.openhab.binding.myuplink.internal.connector.CommunicationStatus;
 import org.openhab.binding.myuplink.internal.handler.MyUplinkThingHandler;
 import org.openhab.binding.myuplink.internal.model.GenericResponseTransformer;
+import org.openhab.binding.myuplink.internal.model.ResponseTransformer;
 import org.openhab.binding.myuplink.internal.model.ValidationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,7 +87,7 @@ public abstract class AbstractCommand extends BufferingResponseListener implemen
     /**
      * generic transformer which just transfers all values in a plain map.
      */
-    protected final GenericResponseTransformer transformer;
+    protected final ResponseTransformer transformer;
 
     /**
      * retry counter.
@@ -113,9 +114,15 @@ public abstract class AbstractCommand extends BufferingResponseListener implemen
      */
     public AbstractCommand(MyUplinkThingHandler handler, RetryOnFailure retryOnFailure,
             ProcessFailureResponse processFailureResponse, JsonResultProcessor resultProcessor) {
+        this(handler, new GenericResponseTransformer(handler), retryOnFailure, processFailureResponse, resultProcessor);
+    }
+
+    public AbstractCommand(MyUplinkThingHandler handler, ResponseTransformer responseTransformer,
+            RetryOnFailure retryOnFailure, ProcessFailureResponse processFailureResponse,
+            JsonResultProcessor resultProcessor) {
         this.gson = new GsonBuilder().setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE).create();
         this.communicationStatus = new CommunicationStatus();
-        this.transformer = new GenericResponseTransformer(handler);
+        this.transformer = responseTransformer;
         this.handler = handler;
         this.processFailureResponse = processFailureResponse;
         this.retryOnFailure = retryOnFailure;

--- a/bundles/org.openhab.binding.myuplink/src/main/java/org/openhab/binding/myuplink/internal/command/device/GetSmartHomeMode.java
+++ b/bundles/org.openhab.binding.myuplink/src/main/java/org/openhab/binding/myuplink/internal/command/device/GetSmartHomeMode.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.myuplink.internal.command.device;
+
+import static org.openhab.binding.myuplink.internal.MyUplinkBindingConstants.*;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.myuplink.internal.command.AbstractCommand;
+import org.openhab.binding.myuplink.internal.command.JsonResultProcessor;
+import org.openhab.binding.myuplink.internal.handler.MyUplinkThingHandler;
+import org.openhab.binding.myuplink.internal.model.SmartHomeModeResponseTransformer;
+
+/**
+ * implements the get sites api call of the site.
+ *
+ * @author Alexander Friese - initial contribution
+ */
+@NonNullByDefault
+public class GetSmartHomeMode extends AbstractCommand {
+    private String url;
+
+    public GetSmartHomeMode(MyUplinkThingHandler handler, String systemId, JsonResultProcessor resultProcessor) {
+        // retry does not make much sense as it is a polling command, command should always succeed therefore update
+        // handler on failure.
+        super(handler, new SmartHomeModeResponseTransformer(handler), RetryOnFailure.NO, ProcessFailureResponse.YES,
+                resultProcessor);
+        this.url = GET_SMART_HOME_MODE_URL.replaceAll("\\{systemId\\}", systemId);
+    }
+
+    @Override
+    protected String getURL() {
+        return this.url;
+    }
+
+    @Override
+    protected String getChannelGroup() {
+        return EMPTY;
+    }
+}

--- a/bundles/org.openhab.binding.myuplink/src/main/java/org/openhab/binding/myuplink/internal/command/device/SetSmartHomeMode.java
+++ b/bundles/org.openhab.binding.myuplink/src/main/java/org/openhab/binding/myuplink/internal/command/device/SetSmartHomeMode.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.myuplink.internal.command.device;
+
+import static org.openhab.binding.myuplink.internal.MyUplinkBindingConstants.*;
+
+import java.nio.charset.StandardCharsets;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.client.util.StringContentProvider;
+import org.eclipse.jetty.http.HttpMethod;
+import org.openhab.binding.myuplink.internal.command.AbstractWriteCommand;
+import org.openhab.binding.myuplink.internal.command.JsonResultProcessor;
+import org.openhab.binding.myuplink.internal.handler.MyUplinkThingHandler;
+import org.openhab.binding.myuplink.internal.model.ValidationException;
+import org.openhab.core.thing.Channel;
+import org.openhab.core.types.Command;
+
+/**
+ * implements the set smart home mode api call of the site.
+ *
+ * @author Anders Alfredsson - initial contribution
+ */
+@NonNullByDefault
+public class SetSmartHomeMode extends AbstractWriteCommand {
+    private String url;
+
+    public SetSmartHomeMode(MyUplinkThingHandler handler, Channel channel, Command command, String systemId,
+            JsonResultProcessor resultProcessor) {
+        // retry does not make much sense as it is a polling command, command should always succeed therefore update
+        // handler on failure.
+        super(handler, channel, command, RetryOnFailure.NO, ProcessFailureResponse.YES, resultProcessor);
+        this.url = SET_SMART_HOME_MODE_URL.replaceAll("\\{systemId\\}", systemId);
+    }
+
+    @Override
+    protected String getURL() {
+        return this.url;
+    }
+
+    @Override
+    protected Request prepareWriteRequest(Request requestToPrepare) throws ValidationException {
+        requestToPrepare.method(HttpMethod.PUT);
+
+        String body = buildJsonObject(JSON_KEY_SMART_HOME_MODE, command.toString());
+
+        StringContentProvider cp = new StringContentProvider(WEB_REQUEST_PATCH_CONTENT_TYPE, body,
+                StandardCharsets.UTF_8);
+
+        requestToPrepare.content(cp);
+
+        return requestToPrepare;
+    }
+}

--- a/bundles/org.openhab.binding.myuplink/src/main/java/org/openhab/binding/myuplink/internal/discovery/MyUplinkDiscoveryService.java
+++ b/bundles/org.openhab.binding.myuplink/src/main/java/org/openhab/binding/myuplink/internal/discovery/MyUplinkDiscoveryService.java
@@ -96,15 +96,16 @@ public class MyUplinkDiscoveryService extends AbstractDiscoveryService implement
         logger.debug("handleSystemDiscovery {}", json);
 
         JsonObject system = json.getAsJsonObject();
+        String systemId = Utils.getAsString(system, JSON_KEY_SYSTEM_ID);
         JsonArray devices = system.getAsJsonArray(JSON_KEY_DEVICES);
         if (devices == null || devices.isEmpty()) {
             logger.info("System discovery failed, no devices found.");
         } else {
-            devices.forEach(this::handleDeviceDiscovery);
+            devices.forEach(device -> handleDeviceDiscovery(device, systemId));
         }
     }
 
-    void handleDeviceDiscovery(JsonElement json) {
+    void handleDeviceDiscovery(JsonElement json, @Nullable String systemId) {
         logger.debug("handleDeviceDiscovery {}", json);
 
         JsonObject device = json.getAsJsonObject();
@@ -116,6 +117,9 @@ public class MyUplinkDiscoveryService extends AbstractDiscoveryService implement
             DiscoveryResultBuilder builder;
             builder = initDiscoveryResultBuilder(DEVICE_GENERIC_DEVICE, id, name);
             builder.withProperty(THING_CONFIG_SERIAL, serial);
+            if (systemId != null) {
+                builder.withProperty(THING_CONFIG_SYSTEM_ID, systemId);
+            }
             thingDiscovered(builder.build());
         }
     }

--- a/bundles/org.openhab.binding.myuplink/src/main/java/org/openhab/binding/myuplink/internal/handler/MyUplinkGenericDeviceHandler.java
+++ b/bundles/org.openhab.binding.myuplink/src/main/java/org/openhab/binding/myuplink/internal/handler/MyUplinkGenericDeviceHandler.java
@@ -27,8 +27,10 @@ import org.openhab.binding.myuplink.internal.Utils;
 import org.openhab.binding.myuplink.internal.command.MyUplinkCommand;
 import org.openhab.binding.myuplink.internal.command.account.GetSystems;
 import org.openhab.binding.myuplink.internal.command.device.GetPoints;
+import org.openhab.binding.myuplink.internal.command.device.GetSmartHomeMode;
 import org.openhab.binding.myuplink.internal.command.device.SetPoints;
 import org.openhab.binding.myuplink.internal.command.device.SetPointsAdvanced;
+import org.openhab.binding.myuplink.internal.command.device.SetSmartHomeMode;
 import org.openhab.binding.myuplink.internal.config.MyUplinkConfiguration;
 import org.openhab.binding.myuplink.internal.connector.CommunicationStatus;
 import org.openhab.binding.myuplink.internal.provider.ChannelFactory;
@@ -131,10 +133,13 @@ public class MyUplinkGenericDeviceHandler extends BaseThingHandler
     @Override
     public MyUplinkCommand buildMyUplinkCommand(Command command, Channel channel) {
         var deviceId = getConfig().get(MyUplinkBindingConstants.THING_CONFIG_ID).toString();
+        var systemId = getConfig().get(THING_CONFIG_SYSTEM_ID).toString();
         var channelTypeId = Utils.getChannelTypeId(channel);
         return switch (channelTypeId) {
             case CHANNEL_TYPE_RW_COMMAND ->
                 new SetPointsAdvanced(this, channel, command, deviceId, this::updateOnlineStatus);
+            case CHANNEL_TYPE_RW_MODE ->
+                new SetSmartHomeMode(this, channel, command, systemId, this::updateOnlineStatus);
             default -> new SetPoints(this, channel, command, deviceId, this::updateOnlineStatus);
         };
     }
@@ -152,11 +157,13 @@ public class MyUplinkGenericDeviceHandler extends BaseThingHandler
      */
     void pollingRun() {
         String deviceId = getConfig().get(THING_CONFIG_ID).toString();
+        String systemId = getConfig().get(THING_CONFIG_SYSTEM_ID).toString();
         logger.debug("polling device data for {}", deviceId);
 
         // proceed if device is online
         if (getThing().getStatus() == ThingStatus.ONLINE) {
             enqueueCommand(new GetPoints(this, deviceId, this::updateOnlineStatus));
+            enqueueCommand(new GetSmartHomeMode(this, systemId, this::updateOnlineStatus));
         }
         enqueueCommand(new GetSystems(this, this::updatePropertiesAndOnlineStatus));
     }

--- a/bundles/org.openhab.binding.myuplink/src/main/java/org/openhab/binding/myuplink/internal/handler/MyUplinkThingHandler.java
+++ b/bundles/org.openhab.binding.myuplink/src/main/java/org/openhab/binding/myuplink/internal/handler/MyUplinkThingHandler.java
@@ -106,7 +106,12 @@ public interface MyUplinkThingHandler extends ThingHandler, ChannelProvider {
             getLogger().debug("Thing is not online, thus no commands will be handled");
             return;
         }
-        enqueueCommand(buildMyUplinkCommand(command, channel));
+
+        try {
+            enqueueCommand(buildMyUplinkCommand(command, channel));
+        } catch (UnsupportedOperationException e) {
+            getLogger().warn("Unsupported command: {}", e.getMessage());
+        }
     }
 
     /**

--- a/bundles/org.openhab.binding.myuplink/src/main/java/org/openhab/binding/myuplink/internal/model/GenericResponseTransformer.java
+++ b/bundles/org.openhab.binding.myuplink/src/main/java/org/openhab/binding/myuplink/internal/model/GenericResponseTransformer.java
@@ -44,7 +44,7 @@ import com.google.gson.JsonObject;
  * @author Alexander Friese - initial contribution
  */
 @NonNullByDefault
-public class GenericResponseTransformer {
+public class GenericResponseTransformer implements ResponseTransformer {
     private final Logger logger = LoggerFactory.getLogger(GenericResponseTransformer.class);
     private final ChannelProvider channelProvider;
     private final @Nullable DynamicChannelProvider dynamicChannelProvider;

--- a/bundles/org.openhab.binding.myuplink/src/main/java/org/openhab/binding/myuplink/internal/model/ResponseTransformer.java
+++ b/bundles/org.openhab.binding.myuplink/src/main/java/org/openhab/binding/myuplink/internal/model/ResponseTransformer.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.myuplink.internal.model;
+
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.thing.Channel;
+import org.openhab.core.types.State;
+
+import com.google.gson.JsonObject;
+
+/**
+ * transforms the http response into the openhab datamodel (instances of State)
+ * this is an interface which can be implemented by different transformer classes
+ *
+ * @author Anders Alfredsson - initial contribution
+ */
+@NonNullByDefault
+public interface ResponseTransformer {
+
+    /**
+     * Transform the received data into a Map of channels and the State they should be updated to
+     *
+     * @param jsonData The input json data
+     * @param group The channel group
+     * @return
+     */
+    Map<Channel, State> transform(JsonObject jsonData, String group);
+}

--- a/bundles/org.openhab.binding.myuplink/src/main/java/org/openhab/binding/myuplink/internal/model/SmartHomeModeResponseTransformer.java
+++ b/bundles/org.openhab.binding.myuplink/src/main/java/org/openhab/binding/myuplink/internal/model/SmartHomeModeResponseTransformer.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.myuplink.internal.model;
+
+import static org.openhab.binding.myuplink.internal.MyUplinkBindingConstants.*;
+
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.myuplink.internal.Utils;
+import org.openhab.binding.myuplink.internal.handler.ChannelProvider;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.thing.Channel;
+import org.openhab.core.types.State;
+import org.openhab.core.types.UnDefType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.JsonObject;
+
+/**
+ * transforms the http response into the openhab datamodel (instances of State)
+ * this is a transformer for the smart home mode data received from the api.
+ *
+ * @author Anders Alfredsson - initial contribution
+ */
+@NonNullByDefault
+public class SmartHomeModeResponseTransformer implements ResponseTransformer {
+    private final Logger logger = LoggerFactory.getLogger(SmartHomeModeResponseTransformer.class);
+    private final ChannelProvider channelProvider;
+
+    public SmartHomeModeResponseTransformer(ChannelProvider channelProvider) {
+        this.channelProvider = channelProvider;
+    }
+
+    public Map<Channel, State> transform(JsonObject jsonData, String group) {
+        String mode = Utils.getAsString(jsonData, JSON_KEY_SMART_HOME_MODE);
+        Channel channel = channelProvider.getChannel(group, CHANNEL_ID_SMART_HOME_MODE);
+
+        if (channel == null) {
+            logger.warn(
+                    "Smart home mode channel not found. This is likely because of a bug. Please report to the developers.");
+            return Map.of();
+        } else {
+            State newState;
+
+            if (mode == null) {
+                newState = UnDefType.UNDEF;
+            } else {
+                newState = new StringType(mode);
+            }
+
+            return Map.of(channel, newState);
+        }
+    }
+}

--- a/bundles/org.openhab.binding.myuplink/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.myuplink/src/main/resources/OH-INF/config/config.xml
@@ -44,6 +44,10 @@
 			<label>Device Id</label>
 			<description>The Id to identify the device.</description>
 		</parameter>
+		<parameter name="systemId" type="text" required="false">
+			<label>System Id</label>
+			<description>The Id of the system the device belongs to.</description>
+		</parameter>
 	</config-description>
 
 </config-description:config-descriptions>

--- a/bundles/org.openhab.binding.myuplink/src/main/resources/OH-INF/thing/readwrite-channel-types.xml
+++ b/bundles/org.openhab.binding.myuplink/src/main/resources/OH-INF/thing/readwrite-channel-types.xml
@@ -14,4 +14,26 @@
 		<label>Generic Command</label>
 		<state readOnly="false"></state>
 	</channel-type>
+	<channel-type id="rwtype-mode">
+		<item-type>String</item-type>
+		<label>Generic Command</label>
+		<state readOnly="false">
+			<options>
+				<option value="Default">Default</option>
+				<option value="Normal">Normal</option>
+				<option value="Away">Away</option>
+				<option value="Vacation">Vacation</option>
+				<option value="Home">Home</option>
+			</options>
+		</state>
+		<command>
+			<options>
+				<option value="Default">Default</option>
+				<option value="Normal">Normal</option>
+				<option value="Away">Away</option>
+				<option value="Vacation">Vacation</option>
+				<option value="Home">Home</option>
+			</options>
+		</command>
+	</channel-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.myuplink/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.myuplink/src/main/resources/OH-INF/thing/thing-types.xml
@@ -22,6 +22,13 @@
 					<property name="validationExpression">[0-9]+:[0-9,]+</property>
 				</properties>
 			</channel>
+			<channel id="smart-home-mode" typeId="rwtype-mode">
+				<label>Smart Home Mode</label>
+				<description>Sets the smart home mode</description>
+				<properties>
+					<property name="validationExpression">\w+</property>
+				</properties>
+			</channel>
 		</channels>
 		<config-description-ref uri="thing-type:myuplink:genericDevice"/>
 	</thing-type>

--- a/bundles/org.openhab.binding.myuplink/src/test/java/org/openhab/binding/myuplink/internal/discovery/MyUplinkDiscoveryServiceTest.java
+++ b/bundles/org.openhab.binding.myuplink/src/test/java/org/openhab/binding/myuplink/internal/discovery/MyUplinkDiscoveryServiceTest.java
@@ -109,7 +109,7 @@ public class MyUplinkDiscoveryServiceTest {
 
         // testdata contains no systems -> no further processing
         verify(discoveryService, never()).handleSystemDiscovery(any());
-        verify(discoveryService, never()).handleDeviceDiscovery(any());
+        verify(discoveryService, never()).handleDeviceDiscovery(any(), any());
         verify(discoveryService, never()).initDiscoveryResultBuilder(any(), any(), any());
     }
 
@@ -125,7 +125,7 @@ public class MyUplinkDiscoveryServiceTest {
         // testdata contains one system
         verify(discoveryService, times(1)).handleSystemDiscovery(any());
         // testdata contains two devices
-        verify(discoveryService, times(2)).handleDeviceDiscovery(any());
+        verify(discoveryService, times(2)).handleDeviceDiscovery(any(), any());
         // builder should be called once for each device
         verify(discoveryService, times(2)).initDiscoveryResultBuilder(any(), any(), any());
 


### PR DESCRIPTION
Needed to do a bit of refactoring to create a ResponseTransformer interface, since the data received from the API endpoint requires a different way of transforming it. Also, the API endpoint requires the systemId instead of the deviceId, so added that as a parameter on all genericDevice Things. It felt unnecessary to create a separate system Thing only for this channel. Not sure what the practical difference is between a system and a device, but if a system has several devices, the only downside with this solution as I can see is that the same channel will be present on all devices. 