### PR TITLE
Add more fixes for invalid unit formats

### DIFF
--- a/bundles/org.openhab.binding.myuplink/src/main/java/org/openhab/binding/myuplink/internal/Utils.java
+++ b/bundles/org.openhab.binding.myuplink/src/main/java/org/openhab/binding/myuplink/internal/Utils.java
@@ -248,6 +248,8 @@ public final class Utils {
         return switch (originalUnit) {
             case "l/m" -> "l/min";
             case "hrs" -> "h";
+            case "m3/h" -> "m³/h";
+            case "days" -> "d";
             default -> originalUnit;
         };
     }


### PR DESCRIPTION
The myUplink api returns some units in the wrong format. This PR adds conversions for 'days' -> 'd' and 'm3/h' -> 'm³/h', so the OH unit parser can understand them.